### PR TITLE
Use one CircularConvolution operator for all data types on a grid

### DIFF
--- a/src/gridoperations/convolution.jl
+++ b/src/gridoperations/convolution.jl
@@ -77,9 +77,11 @@ end
 
 function mul!(out, C::CircularConvolution{M, N, T}, B) where {M, N, T}
     FFTW.set_num_threads(2)
-    @assert size(out) == size(B) == (M, N)
+    MB, NB = size(B)
+    #@assert size(out) == size(B) == (M, N)
+    @assert size(out) == (MB, NB)
 
-    inds = CartesianIndices((M,N))
+    inds = CartesianIndices((MB,NB))
     fill!(C.paddedSpace, 0)
     copyto!(C.paddedSpace, inds, B, inds)
     mul!(C.Â, C.F, C.paddedSpace)
@@ -89,7 +91,7 @@ function mul!(out, C::CircularConvolution{M, N, T}, B) where {M, N, T}
     mul!(C.paddedSpace, C.F⁻¹, C.Â)
 
     #copyto!(out, inds, C.paddedSpace, CartesianIndices((M:2M-1,N:2N-1)))
-    copyto!(out, inds, C.paddedSpace, CartesianIndices((M+1:2M,N+1:2N)))
+    copyto!(out, inds, C.paddedSpace, CartesianIndices((M+1:M+MB,N+1:N+NB)))
 
 end
 

--- a/test/fields.jl
+++ b/test/fields.jl
@@ -471,7 +471,14 @@ import LinearAlgebra: norm, dot
     @test lapψ[i,j]≈1.0
     @test isapprox(maximum(abs.(lapψ[Not(i),:])),0.0;atol=10.0*eps()) &&
             isapprox(maximum(abs.(lapψ[:,Not(j)])),0.0;atol=10.0*eps())
+
+    ψ = L\nodeunit
+    lapψ = L*ψ
+    @test lapψ[i,j]≈1.0
+    @test isapprox(maximum(abs.(lapψ[Not(i),:])),0.0;atol=10.0*eps()) &&
+            isapprox(maximum(abs.(lapψ[:,Not(j)])),0.0;atol=10.0*eps())
   end
+
 
   @testset "LGF for Helmholtz equation" begin
     alpha = 0.02


### PR DESCRIPTION
This fix relaxes the requirements that a `CircularConvolution` operator has the same size as input and output data. This allows one operator to be used for all types of data.