### PR TITLE
Extensions to grid interpolation

### DIFF
--- a/src/gridoperations/shift.jl
+++ b/src/gridoperations/shift.jl
@@ -229,6 +229,38 @@ end
 # (Dual/Primal) edges to (Primal/Dual) edges. These require some rethinking,
 # since they lead to broadened stencils.
 
+function grid_interpolate!(dual::XEdges{Dual, NX, NY},
+                           primal::XEdges{Primal, NX, NY}) where {NX, NY}
+
+    view(dual,1:NX-1,2:NY-1) .= 0.25.*(view(primal,1:NX-1,2:NY-1) .+ view(primal,2:NX,2:NY-1) .+
+                                       view(primal,1:NX-1,1:NY-2) .+ view(primal,2:NX,1:NY-2))
+    dual
+end
+
+function grid_interpolate!(dual::YEdges{Dual, NX, NY},
+                           primal::YEdges{Primal, NX, NY}) where {NX, NY}
+
+    view(dual,2:NX-1,1:NY-1) .= 0.25.*(view(primal,2:NX-1,1:NY-1) .+ view(primal,1:NX-2,1:NY-1) .+
+                                       view(primal,2:NX-1,2:NY)   .+ view(primal,1:NX-2,2:NY))
+    dual
+end
+
+function grid_interpolate!(primal::XEdges{Primal, NX, NY},
+                           dual::XEdges{Dual, NX, NY}) where {NX, NY}
+
+    view(primal,2:NX-1,1:NY-1) .= 0.25.*(view(dual,2:NX-1,1:NY-1) .+ view(dual,1:NX-2,1:NY-1) .+
+                                         view(dual,2:NX-1,2:NY)   .+ view(dual,1:NX-2,2:NY))
+    primal
+end
+
+function grid_interpolate!(primal::YEdges{Primal, NX, NY},
+                           dual::YEdges{Dual, NX, NY}) where {NX, NY}
+
+    view(primal,1:NX-1,2:NY-1) .= 0.25.*(view(dual,1:NX-1,2:NY-1) .+ view(dual,2:NX,2:NY-1) .+
+                                         view(dual,1:NX-1,1:NY-2) .+ view(dual,2:NX,1:NY-2))
+    primal
+end
+
 """
     grid_interpolate!(v::Edges{Dual/Primal},q::Edges{Primal/Dual})
 
@@ -263,16 +295,20 @@ v (in grid orientation)
  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 ```
 """
+
+
 function grid_interpolate!(dual::Edges{Dual, NX, NY},
                 primal::Edges{Primal, NX, NY}) where {NX, NY}
 
-    uₚ = primal.u
-    view(dual.u,1:NX-1,2:NY-1) .= 0.25.*(view(uₚ,1:NX-1,2:NY-1) .+ view(uₚ,2:NX,2:NY-1) .+
-                                       view(uₚ,1:NX-1,1:NY-2) .+ view(uₚ,2:NX,1:NY-2))
+    grid_interpolate!(dual.u,primal.u)
+    grid_interpolate!(dual.v,primal.v)
+    #uₚ = primal.u
+    #view(dual.u,1:NX-1,2:NY-1) .= 0.25.*(view(uₚ,1:NX-1,2:NY-1) .+ view(uₚ,2:NX,2:NY-1) .+
+    #                                   view(uₚ,1:NX-1,1:NY-2) .+ view(uₚ,2:NX,1:NY-2))
 
-    vₚ = primal.v
-    view(dual.v,2:NX-1,1:NY-1) .= 0.25.*(view(vₚ,2:NX-1,1:NY-1) .+ view(vₚ,1:NX-2,1:NY-1) .+
-                                       view(vₚ,2:NX-1,2:NY)   .+ view(vₚ,1:NX-2,2:NY))
+    #vₚ = primal.v
+    #view(dual.v,2:NX-1,1:NY-1) .= 0.25.*(view(vₚ,2:NX-1,1:NY-1) .+ view(vₚ,1:NX-2,1:NY-1) .+
+    #                                   view(vₚ,2:NX-1,2:NY)   .+ view(vₚ,1:NX-2,2:NY))
 
     # @inbounds for y in 2:NY-1, x in 1:NX-1
     #     dual.u[x,y] = (uₚ[x,y] + uₚ[x+1,y] + uₚ[x,y-1] + uₚ[x+1,y-1])/4
@@ -291,12 +327,14 @@ end
 
 function grid_interpolate!(primal::Edges{Primal, NX, NY},
                 dual::Edges{Dual, NX, NY}) where {NX, NY}
-    uₚ = dual.u
-    view(primal.u,2:NX-1,1:NY-1) .= 0.25.*(view(uₚ,2:NX-1,1:NY-1) .+ view(uₚ,1:NX-2,1:NY-1) .+
-                                         view(uₚ,2:NX-1,2:NY)   .+ view(uₚ,1:NX-2,2:NY))
-    vₚ = dual.v
-    view(primal.v,1:NX-1,2:NY-1) .= 0.25.*(view(vₚ,1:NX-1,2:NY-1) .+ view(vₚ,2:NX,2:NY-1) .+
-                                         view(vₚ,1:NX-1,1:NY-2) .+ view(vₚ,2:NX,1:NY-2))
+    grid_interpolate!(primal.u,dual.u)
+    grid_interpolate!(primal.v,dual.v)
+    #uₚ = dual.u
+    #view(primal.u,2:NX-1,1:NY-1) .= 0.25.*(view(uₚ,2:NX-1,1:NY-1) .+ view(uₚ,1:NX-2,1:NY-1) .+
+    #                                     view(uₚ,2:NX-1,2:NY)   .+ view(uₚ,1:NX-2,2:NY))
+    #vₚ = dual.v
+    #view(primal.v,1:NX-1,2:NY-1) .= 0.25.*(view(vₚ,1:NX-1,2:NY-1) .+ view(vₚ,2:NX,2:NY-1) .+
+    #                                     view(vₚ,1:NX-1,1:NY-2) .+ view(vₚ,2:NX,1:NY-2))
     # @inbounds for y in 1:NY-1, x in 2:NX-1
     #     primal.u[x,y] = (uₚ[x,y] + uₚ[x-1,y] + uₚ[x,y+1] + uₚ[x-1,y+1])/4
     # end
@@ -310,6 +348,26 @@ end
 
 function grid_interpolate(dual::Edges{Dual, NX, NY}) where {NX, NY}
     grid_interpolate!(Edges(Primal, dual), dual)
+end
+
+"""
+    grid_interpolate!(v::Nodes{Dual/Primal},q::Nodes{Primal/Dual})
+
+Interpolate the primal (resp. dual) node data `q` to the
+edges of the dual (resp. primal) nodes, and return the result in `v`.
+"""
+function grid_interpolate!(primal::Nodes{Primal, NX, NY},
+                           dual::Nodes{Dual, NX, NY}) where {NX, NY}
+    view(primal,1:NX-1,1:NY-1) .= 0.25.*(view(dual,1:NX-1,1:NY-1) .+ view(dual,2:NX,1:NY-1) .+
+                                         view(dual,1:NX-1,2:NY)   .+ view(dual,2:NX,2:NY))
+    primal
+end
+
+function grid_interpolate!(dual::Nodes{Dual, NX, NY},
+                           primal::Nodes{Primal, NX, NY}) where {NX, NY}
+    view(dual,2:NX-1,2:NY-1) .= 0.25.*(view(primal,1:NX-2,1:NY-2) .+ view(primal,2:NX-1,1:NY-2) .+
+                                       view(primal,1:NX-2,2:NY-1) .+ view(primal,2:NX-1,2:NY-1))
+    dual
 end
 
 

--- a/test/fields.jl
+++ b/test/fields.jl
@@ -366,6 +366,9 @@ import LinearAlgebra: norm, dot, mul!
   randomize!(f1,offset=offset)
   randomize!(f2,offset=offset)
 
+  w = Nodes(Dual,u)
+  randomize!(w,offset=offset)
+
   dq = EdgeGradient(Primal,v)
   dv = EdgeGradient(Primal,v)
   dqd = EdgeGradient(Dual,v)
@@ -383,7 +386,10 @@ import LinearAlgebra: norm, dot, mul!
 
   qtmp = Edges(Primal,u)
   qtmpd = Edges(Dual,u)
+  qtmp1d = Edges(Dual,u)
+  qtmp2d = Edges(Dual,u)
   ftmp = Nodes(Primal,u)
+  wtmp = Nodes(Dual,u)
   utmp = EdgeGradient(Primal,u)
   utmpd = EdgeGradient(Dual,u)
 
@@ -445,6 +451,19 @@ import LinearAlgebra: norm, dot, mul!
     rhsn .= ftmp + f1∘divergence(u)
     @test isapprox(norm(lhsn-rhsn),0.0,atol=100.0*eps())
 
+    # div(u*w) = grad(w).u + w*(div u)
+    lhsnd .= 0
+    rhsnd .= 0
+    qtmp1d .= 0
+    qtmp2d .= 0
+    lhsnd .= divergence(grid_interpolate!(qtmp1d,u)∘grid_interpolate!(qtmp2d,w))
+    qtmp1d .= 0
+    grid_interpolate!(rhsnd,grid_interpolate!(qtmp1d,u)∘grad(w))
+    wtmp .= 0
+    rhsnd .+= w∘grid_interpolate!(wtmp,divergence(u))
+    @test isapprox(norm(lhsnd-rhsnd),0.0,atol=100.0*eps())
+
+
     # div(uv) = u.grad v + (div u)v
     divuv = zero(u)
     uv = EdgeGradient(Primal,u)
@@ -488,6 +507,7 @@ import LinearAlgebra: norm, dot, mul!
     product!(vdivu,grid_interpolate!(qtmpd,divergence(ud)),vd)
 
     @test isapprox(norm(divuv - ugradv - vdivu),0.0,atol=100.0*eps())
+
 
 
   end


### PR DESCRIPTION
This PR extends grid interpolation routines in `grid_interpolate!` to interpolate in multiple staggered directions at once, e.g., dual nodes to primal nodes, and vice versa.