### PR TITLE
Fixed the method ambiguity on interp * reg for other grid data types

### DIFF
--- a/examples/Point to field operations.ipynb
+++ b/examples/Point to field operations.ipynb
@@ -17704,15 +17704,15 @@
    "lastKernelId": null
   },
   "kernelspec": {
-   "display_name": "Julia 1.5.3",
+   "display_name": "Julia 1.6.0",
    "language": "julia",
-   "name": "julia-1.5"
+   "name": "julia-1.6"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.5.3"
+   "version": "1.6.0"
   }
  },
  "nbformat": 4,

--- a/src/points/regularization.jl
+++ b/src/points/regularization.jl
@@ -730,7 +730,12 @@ function mul!(C::Array{Float64},Emat::InterpolationMatrix{G,F},
   return C
 end
 
+
 (*)(Emat::InterpolationMatrix,Hmat::RegularizationMatrix) =
+        mul!(Array{eltype(Emat),2}(undef,Emat.M.n,Hmat.M.n),Emat,Hmat)
+
+# This fixes a method ambiguity
+(*)(Emat::InterpolationMatrix{G,F},Hmat::RegularizationMatrix) where {G <: Union{VectorGridData,TensorGridData},F}=
         mul!(Array{eltype(Emat),2}(undef,Emat.M.n,Hmat.M.n),Emat,Hmat)
 
 

--- a/test/points.jl
+++ b/test/points.jl
@@ -411,6 +411,9 @@ using LinearAlgebra
   H̃(f2,p)
   @test f.u ≈ f2.u && f.v ≈ f2.v
 
+  # test for method ambiguity
+  Cmat = Ẽmat*Hmat
+
   p = NodePair(Dual,(nx,ny))
   p2 = deepcopy(p)
   Hmat = RegularizationMatrix(H,f,p)
@@ -431,6 +434,9 @@ using LinearAlgebra
   H̃(f2,p)
   @test f.u ≈ f2.u && f.v ≈ f2.v
 
+  # test for method ambiguity
+  Cmat = Ẽmat*Hmat
+
   p = NodePair(Primal,(nx,ny))
   p2 = deepcopy(p)
   Hmat = RegularizationMatrix(H,f,p)
@@ -449,6 +455,9 @@ using LinearAlgebra
   mul!(f,Ẽmat,p)
   H̃(f2,p)
   @test f.u ≈ f2.u && f.v ≈ f2.v
+
+  # test for method ambiguity
+  Cmat = Ẽmat*Hmat
 
   f = TensorData(X)
   f.dudx .= rand(n)
@@ -479,6 +488,9 @@ using LinearAlgebra
   H̃(f2,p)
   @test f.dudx ≈ f2.dudx && f.dudy ≈ f2.dudy && f.dvdx ≈ f2.dvdx && f.dvdy ≈ f2.dvdy
 
+  # test for method ambiguity
+  Cmat = Ẽmat*Hmat
+
   p = EdgeGradient(Primal,(nx,ny))
   p2 = deepcopy(p)
   Hmat = RegularizationMatrix(H,f,p)
@@ -506,7 +518,8 @@ using LinearAlgebra
   mul!(p,Hsmat,f)
   @test p.dudx ≈ p2.dudx && p.dudy ≈ p2.dudy && p.dvdx ≈ p2.dvdx && p.dvdy ≈ p2.dvdy
 
-
+  # test for method ambiguity
+  Cmat = Ẽmat*Hmat
 
   end
 


### PR DESCRIPTION
… now with more complete testing. This should fix JuliaIBPM/ViscousFlow.jl#67