### PR TITLE
Ensure efficient grid convolution

### DIFF
--- a/src/gridoperations/helmholtz.jl
+++ b/src/gridoperations/helmholtz.jl
@@ -107,13 +107,13 @@ for (lf,inplace) in ((:plan_helmholtz,false),
     end
 
     @eval function $lf(nx::Int, ny::Int,α::Number;
-        with_inverse = false, fftw_flags = FFTW.ESTIMATE, dx = 1.0)
-        $lf((nx, ny), α, with_inverse = with_inverse, fftw_flags = fftw_flags, dx = dx)
+        with_inverse = false, fftw_flags = FFTW.ESTIMATE, dx = 1.0, nthreads = length(Sys.cpu_info()))
+        $lf((nx, ny), α, with_inverse = with_inverse, fftw_flags = fftw_flags, dx = dx, , nthreads = nthreads)
     end
 
-    @eval function $lf(nodes::Nodes{C,NX,NY,T},α::Number;
-        with_inverse = false, fftw_flags = FFTW.ESTIMATE, dx = 1.0) where {C<:CellType,NX,NY,T<:ComplexF64}
-        $lf(node_inds(C,(NX,NY)), α, with_inverse = with_inverse, fftw_flags = fftw_flags, dx = dx)
+    @eval function $lf(nodes::ScalarGridData{NX,NY,T},α::Number;
+        with_inverse = false, fftw_flags = FFTW.ESTIMATE, dx = 1.0, nthreads = length(Sys.cpu_info())) where {NX,NY,T<:ComplexF64}
+        $lf((NX,NY), α, with_inverse = with_inverse, fftw_flags = fftw_flags, dx = dx, , nthreads = nthreads)
     end
 end
 

--- a/src/gridoperations/helmholtz.jl
+++ b/src/gridoperations/helmholtz.jl
@@ -96,7 +96,7 @@ end
 for (lf,inplace) in ((:plan_helmholtz,false),
                      (:plan_helmholtz!,true))
     @eval function $lf(dims::Tuple{Int,Int},α::Number;
-                   with_inverse = false, fftw_flags = FFTW.ESTIMATE, dx = 1.0)
+                   with_inverse = false, fftw_flags = FFTW.ESTIMATE, dx = 1.0, nthreads = length(Sys.cpu_info()))
         NX, NY = dims
         if !with_inverse
             return Helmholtz{NX, NY, false, dx, $inplace}(nothing)

--- a/src/gridoperations/helmholtz.jl
+++ b/src/gridoperations/helmholtz.jl
@@ -108,12 +108,12 @@ for (lf,inplace) in ((:plan_helmholtz,false),
 
     @eval function $lf(nx::Int, ny::Int,α::Number;
         with_inverse = false, fftw_flags = FFTW.ESTIMATE, dx = 1.0, nthreads = length(Sys.cpu_info()))
-        $lf((nx, ny), α, with_inverse = with_inverse, fftw_flags = fftw_flags, dx = dx, , nthreads = nthreads)
+        $lf((nx, ny), α, with_inverse = with_inverse, fftw_flags = fftw_flags, dx = dx, nthreads = nthreads)
     end
 
     @eval function $lf(nodes::ScalarGridData{NX,NY,T},α::Number;
         with_inverse = false, fftw_flags = FFTW.ESTIMATE, dx = 1.0, nthreads = length(Sys.cpu_info())) where {NX,NY,T<:ComplexF64}
-        $lf((NX,NY), α, with_inverse = with_inverse, fftw_flags = fftw_flags, dx = dx, , nthreads = nthreads)
+        $lf((NX,NY), α, with_inverse = with_inverse, fftw_flags = fftw_flags, dx = dx, nthreads = nthreads)
     end
 end
 

--- a/src/gridoperations/intfact.jl
+++ b/src/gridoperations/intfact.jl
@@ -98,8 +98,10 @@ for (lf,inplace) in ((:plan_intfact,false),
         IntFact{NX, NY, signType, $inplace}(a_internal,CircularConvolution(qtab, fftw_flags,nthreads=nthreads))
       end
 
-      @eval $lf(a::Real,w::ScalarGridData; fftw_flags = FFTW.ESTIMATE, nthreads = length(Sys.cpu_info())) where {T<:CellType,NX,NY} =
-          $lf(a,size(w), fftw_flags = fftw_flags, nthreads = nthreads)
+      # Base the size on the dual grid associated with any grid data, since this
+      # is what the efficient grid size in PhysicalGrid has been established with
+      @eval $lf(a::Real,w::ScalarGridData{NX,NY}; fftw_flags = FFTW.ESTIMATE, nthreads = length(Sys.cpu_info())) where {T<:CellType,NX,NY} =
+          $lf(a,(NX,NY), fftw_flags = fftw_flags, nthreads = nthreads)
 
 
 end

--- a/src/gridoperations/laplacian.jl
+++ b/src/gridoperations/laplacian.jl
@@ -288,9 +288,11 @@ for (lf,inplace) in ((:plan_laplacian,false),
         $lf((nx, ny), with_inverse = with_inverse, fftw_flags = fftw_flags, factor = factor, dx = dx, dtype = dtype, nthreads = nthreads)
     end
 
-    @eval function $lf(w::ScalarGridData;
+    # Base the size on the dual grid associated with any grid data, since this
+    # is what the efficient grid size in PhysicalGrid has been established with
+    @eval function $lf(w::ScalarGridData{NX,NY};
         with_inverse = false, fftw_flags = FFTW.ESTIMATE, factor = 1.0, dx = 1.0, dtype = Float64, nthreads = length(Sys.cpu_info())) where {T<:CellType,NX,NY}
-        $lf(size(w), with_inverse = with_inverse, fftw_flags = fftw_flags, factor = factor, dx = dx, dtype = dtype, nthreads = nthreads)
+        $lf((NX,NY), with_inverse = with_inverse, fftw_flags = fftw_flags, factor = factor, dx = dx, dtype = dtype, nthreads = nthreads)
     end
 end
 


### PR DESCRIPTION
This PR addresses an issue in which the grid data used to establish any operations that utilize FFT-based convolutions (`Laplacian`, `IntFact`,  `Helmholtz`) were not sizing the convolution with the underlying dual node grid. This dual node grid is the maximal grid, and is the one that is originally sized by `PhysicalGrid` to ensure it is efficient for FFTs (i.e., product of prime powers)