### PR TITLE
Build convolution operators on any grid data

### DIFF
--- a/src/gridoperations/helmholtz.jl
+++ b/src/gridoperations/helmholtz.jl
@@ -114,7 +114,7 @@ for (lf,inplace) in ((:plan_helmholtz,false),
         $lf((nx, ny), α, with_inverse = with_inverse, fftw_flags = fftw_flags, factor = factor, dx = dx, nthreads = nthreads)
     end
 
-    @eval function $lf(nodes::ScalarGridData{NX,NY,T},α::Number;
+    @eval function $lf(::GridData{NX,NY,T},α::Number;
         with_inverse = false, fftw_flags = FFTW.ESTIMATE, factor::Number = 1.0, dx = 1.0, nthreads = length(Sys.cpu_info())) where {NX,NY,T<:ComplexF64}
         $lf((NX,NY), α, with_inverse = with_inverse, fftw_flags = fftw_flags, factor = factor, dx = dx, nthreads = nthreads)
     end

--- a/src/gridoperations/intfact.jl
+++ b/src/gridoperations/intfact.jl
@@ -100,7 +100,7 @@ for (lf,inplace) in ((:plan_intfact,false),
 
       # Base the size on the dual grid associated with any grid data, since this
       # is what the efficient grid size in PhysicalGrid has been established with
-      @eval $lf(a::Real,w::ScalarGridData{NX,NY}; fftw_flags = FFTW.ESTIMATE, nthreads = length(Sys.cpu_info())) where {T<:CellType,NX,NY} =
+      @eval $lf(a::Real,::GridData{NX,NY}; fftw_flags = FFTW.ESTIMATE, nthreads = length(Sys.cpu_info())) where {T<:CellType,NX,NY} =
           $lf(a,(NX,NY), fftw_flags = fftw_flags, nthreads = nthreads)
 
 

--- a/src/gridoperations/laplacian.jl
+++ b/src/gridoperations/laplacian.jl
@@ -290,7 +290,7 @@ for (lf,inplace) in ((:plan_laplacian,false),
 
     # Base the size on the dual grid associated with any grid data, since this
     # is what the efficient grid size in PhysicalGrid has been established with
-    @eval function $lf(w::ScalarGridData{NX,NY};
+    @eval function $lf(::GridData{NX,NY};
         with_inverse = false, fftw_flags = FFTW.ESTIMATE, factor = 1.0, dx = 1.0, dtype = Float64, nthreads = length(Sys.cpu_info())) where {T<:CellType,NX,NY}
         $lf((NX,NY), with_inverse = with_inverse, fftw_flags = fftw_flags, factor = factor, dx = dx, dtype = dtype, nthreads = nthreads)
     end

--- a/test/fields.jl
+++ b/test/fields.jl
@@ -519,6 +519,8 @@ import LinearAlgebra: norm, dot, mul!
 
   L = plan_laplacian(nx,ny;with_inverse=true)
 
+  _size(::CartesianGrids.Laplacian{NX,NY}) where {NX,NY} = NX,NY
+
   @testset "Laplacian of the LGF" begin
     ψ = L\cellunit
     lapψ = L*ψ
@@ -561,6 +563,10 @@ import LinearAlgebra: norm, dot, mul!
     ψ = L2\nodeunit
     lapψ = L2*ψ
     @test lapψ[i,j]≈1.0
+
+
+    L2_2 = plan_laplacian(Edges(Primal,nodeunit),with_inverse=true)
+    @test _size(L2_2) == _size(L2)
 
   end
 


### PR DESCRIPTION
Allow Laplacian, IntFact, and Helmholtz operators to be built on any grid data, since it only sets the size