### PR TITLE
Fix rendering of figures in the Documentation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,6 @@ jobs:
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
-      - run: julia --project=docs -e 'ENV["PYTHON"]=""; using Pkg; Pkg.add("Conda"); using Conda; Conda.add("matplotlib"); Conda.add("pyqt"); Pkg.add("PyCall"); Pkg.build("PyCall"); Pkg.add("PyPlot")'
       - run: julia --project=docs docs/make.jl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,4 @@
 [deps]
-CartesianGrids = "3e975e5d-2cf8-4263-9573-8460aaf534d9"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,7 +1,5 @@
 [deps]
-Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
+CartesianGrids = "3e975e5d-2cf8-4263-9573-8460aaf534d9"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
-PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,7 +15,7 @@ Many of the core aspects of the fluid-body interaction are based on the immersed
 
 This package works on Julia `1.0` and higher and is registered in the general Julia registry. To install, type
 ```julia
-]add CartesianGrids
+] add CartesianGrids
 ```
 
 Then type

--- a/docs/src/manual/fielddata.md
+++ b/docs/src/manual/fielddata.md
@@ -9,7 +9,6 @@ end
 ```@setup create
 using CartesianGrids
 using Plots
-pyplot()
 ```
 
 Let's see an example of creating a blank set of dual node data and filling it with
@@ -27,6 +26,4 @@ this in place of the size:
 q = Edges(Primal,w);
 q.u[2,3] = 1;
 q
-```
-
 ```

--- a/docs/src/manual/finitediff.md
+++ b/docs/src/manual/finitediff.md
@@ -23,7 +23,6 @@ end
 ```@setup create
 using CartesianGrids
 using Plots
-pyplot()
 ```
 
 ## Field differencing operations
@@ -133,6 +132,7 @@ L = plan_laplacian(w,with_inverse=true)
 plot(L\w)
 savefig("Linvw.svg"); nothing # hide
 ```
+
 ![](Linvw.svg)
 
 The influence is not affected by the narrow grid dimensions.

--- a/docs/src/manual/finitediff.md
+++ b/docs/src/manual/finitediff.md
@@ -132,7 +132,6 @@ L = plan_laplacian(w,with_inverse=true)
 plot(L\w)
 savefig("Linvw.svg"); nothing # hide
 ```
-
 ![](Linvw.svg)
 
 The influence is not affected by the narrow grid dimensions.

--- a/docs/src/manual/immersed.md
+++ b/docs/src/manual/immersed.md
@@ -109,7 +109,6 @@ with each discrete point. These arguments are used to weight the sum.
 ```@setup regularize
 using CartesianGrids
 using Plots
-pyplot()
 ```
 
 ```@repl regularize


### PR DESCRIPTION
At the moment the figures in the documentation are not properly rendered. This PR enables the documentation to plot using Julia's native Plots package instead of falling back to using Python's Matplotlib via PyCall/PyPlot. The figures should appear now! Locally, I can build the docs using

```
$ julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'; julia --project=docs docs/make.jl
```

and then opening `docs/build/index.html` in a browser.
