### PR TITLE
Fixed a few unnecessary memory allocation issues

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+CartesianGrids = "3e975e5d-2cf8-4263-9573-8460aaf534d9"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/src/fields/scalargrid.jl
+++ b/src/fields/scalargrid.jl
@@ -32,7 +32,7 @@ macro scalarfield(wrapper,primaldn,dualdn)
 
     `$($wrapper)` is a wrapper for scalar-valued data that lie at the centers of either dual cells or
     primary cells. A `$($wrapper)` type can be accessed by indexing like any other array,
-    and allows the use of [`size`](@ref), [`similar`](@ref), [`zero`](@ref).
+    and allows the use of `size`, `similar`, `zero` functions.
 
     # Constructors
     - `$($wrapper)(C,dims)` creates a field of zeros in cells of type `C` (where `C` is

--- a/src/gridoperations/innerproducts.jl
+++ b/src/gridoperations/innerproducts.jl
@@ -17,7 +17,10 @@ Computes the inner product between two sets of dual node data on the same grid.
 function dot(p1::Nodes{Dual,NX,NY},p2::Nodes{Dual,NX,NY}) where {NX,NY}
   # remember that sizes NX and NY include the ghost cells
   dims = node_inds(Dual,(NX,NY))
-  return dot(p1[2:dims[1]-1,2:dims[2]-1],p2[2:dims[1]-1,2:dims[2]-1])/((NX-2)*(NY-2))
+  p1_int = view(p1,2:dims[1]-1,2:dims[2]-1)
+  p2_int = view(p2,2:dims[1]-1,2:dims[2]-1)
+  return dot(p1_int,p2_int)/((NX-2)*(NY-2))
+
 end
 
 """
@@ -30,13 +33,13 @@ function dot(p1::Nodes{Primal,NX,NY},p2::Nodes{Primal,NX,NY}) where {NX,NY}
   dims = node_inds(Primal,(NX,NY))
 
   # interior
-  tmp = dot(p1[2:dims[1]-1,2:dims[2]-1],p2[2:dims[1]-1,2:dims[2]-1])
+  tmp = dot(view(p1,2:dims[1]-1,2:dims[2]-1),view(p2,2:dims[1]-1,2:dims[2]-1))
 
   # boundaries
-  tmp += 0.5*dot(p1[1,2:dims[2]-1],      p2[1,2:dims[2]-1])
-  tmp += 0.5*dot(p1[dims[1],2:dims[2]-1],p2[dims[1],2:dims[2]-1])
-  tmp += 0.5*dot(p1[2:dims[1]-1,1],      p2[2:dims[1]-1,1])
-  tmp += 0.5*dot(p1[2:dims[1]-1,dims[2]],p2[2:dims[1]-1,dims[2]])
+  tmp += 0.5*dot(view(p1,1,2:dims[2]-1),      view(p2,1,2:dims[2]-1))
+  tmp += 0.5*dot(view(p1,dims[1],2:dims[2]-1),view(p2,dims[1],2:dims[2]-1))
+  tmp += 0.5*dot(view(p1,2:dims[1]-1,1),      view(p2,2:dims[1]-1,1))
+  tmp += 0.5*dot(view(p1,2:dims[1]-1,dims[2]),view(p2,2:dims[1]-1,dims[2]))
 
   # corners -- use dot to ensure it works for complex types
   tmp += 0.25*dot([p1[1,1],p1[dims[1],1],p1[1,dims[2]],p1[dims[1],dims[2]]],
@@ -57,11 +60,11 @@ function dot(p1::XEdges{Dual,NX,NY},p2::XEdges{Dual,NX,NY}) where {NX,NY}
   udims = xedge_inds(Dual,(NX,NY))
 
   # interior
-  tmp = dot(p1[2:udims[1]-1,2:udims[2]-1],p2[2:udims[1]-1,2:udims[2]-1])
+  tmp = dot(view(p1,2:udims[1]-1,2:udims[2]-1),view(p2,2:udims[1]-1,2:udims[2]-1))
 
   # boundaries
-  tmp += 0.5*dot(p1[1,       2:udims[2]-1],p2[1,       2:udims[2]-1])
-  tmp += 0.5*dot(p1[udims[1],2:udims[2]-1],p2[udims[1],2:udims[2]-1])
+  tmp += 0.5*dot(view(p1,1,2:udims[2]-1),view(p2,1,2:udims[2]-1))
+  tmp += 0.5*dot(view(p1,udims[1],2:udims[2]-1),view(p2,udims[1],2:udims[2]-1))
 
   return tmp/((NX-2)*(NY-2))
 end
@@ -76,11 +79,11 @@ function dot(p1::YEdges{Dual,NX,NY},p2::YEdges{Dual,NX,NY}) where {NX,NY}
   vdims = yedge_inds(Dual,(NX,NY))
 
   # interior
-  tmp = dot(p1[2:vdims[1]-1,2:vdims[2]-1],p2[2:vdims[1]-1,2:vdims[2]-1])
+  tmp = dot(view(p1,2:vdims[1]-1,2:vdims[2]-1),view(p2,2:vdims[1]-1,2:vdims[2]-1))
 
   # boundaries
-  tmp += 0.5*dot(p1[2:vdims[1]-1,1],       p2[2:vdims[1]-1,1])
-  tmp += 0.5*dot(p1[2:vdims[1]-1,vdims[2]],p2[2:vdims[1]-1,vdims[2]])
+  tmp += 0.5*dot(view(p1,2:vdims[1]-1,1),view(p2,2:vdims[1]-1,1))
+  tmp += 0.5*dot(view(p1,2:vdims[1]-1,vdims[2]),view(p2,2:vdims[1]-1,vdims[2]))
 
   return tmp/((NX-2)*(NY-2))
 end
@@ -97,11 +100,11 @@ function dot(p1::XEdges{Primal,NX,NY},p2::XEdges{Primal,NX,NY}) where {NX,NY}
   udims = xedge_inds(Primal,(NX,NY))
 
   # interior
-  tmp = dot(p1[2:udims[1]-1,2:udims[2]-1],p2[2:udims[1]-1,2:udims[2]-1])
+  tmp = dot(view(p1,2:udims[1]-1,2:udims[2]-1),view(p2,2:udims[1]-1,2:udims[2]-1))
 
   # boundaries
-  tmp += 0.5*dot(p1[2:udims[1]-1,1],       p2[2:udims[1]-1,1])
-  tmp += 0.5*dot(p1[2:udims[1]-1,udims[2]],p2[2:udims[1]-1,udims[2]])
+  tmp += 0.5*dot(view(p1,2:udims[1]-1,1),view(p2,2:udims[1]-1,1))
+  tmp += 0.5*dot(view(p1,2:udims[1]-1,udims[2]),view(p2,2:udims[1]-1,udims[2]))
 
   return tmp/((NX-2)*(NY-2))
 end
@@ -116,11 +119,11 @@ function dot(p1::YEdges{Primal,NX,NY},p2::YEdges{Primal,NX,NY}) where {NX,NY}
   vdims = yedge_inds(Primal,(NX,NY))
 
   # interior
-  tmp = dot(p1[2:vdims[1]-1,2:vdims[2]-1],p2[2:vdims[1]-1,2:vdims[2]-1])
+  tmp = dot(view(p1,2:vdims[1]-1,2:vdims[2]-1),view(p2,2:vdims[1]-1,2:vdims[2]-1))
 
   # boundaries
-  tmp += 0.5*dot(p1[1,       2:vdims[2]-1],p2[1,       2:vdims[2]-1])
-  tmp += 0.5*dot(p1[vdims[1],2:vdims[2]-1],p2[vdims[1],2:vdims[2]-1])
+  tmp += 0.5*dot(view(p1,1,2:vdims[2]-1),view(p2,1,2:vdims[2]-1))
+  tmp += 0.5*dot(view(p1,vdims[1],2:vdims[2]-1),view(p2,vdims[1],2:vdims[2]-1))
 
   return tmp/((NX-2)*(NY-2))
 end

--- a/src/gridoperations/intfact.jl
+++ b/src/gridoperations/intfact.jl
@@ -126,7 +126,7 @@ default, it takes this number from `L`.
 exp(L::Laplacian{NX,NY},a,prototype=Nodes(Dual,(NX,NY));nthreads=MAX_NTHREADS) where {NX,NY} =
             plan_intfact(L.factor*a,prototype;nthreads=nthreads)
 # Do not use the number of threads in L (if it has any), since it is not
-# meaningful for the integrating factor tests.            
+# meaningful for the integrating factor tests.
 
 """
     exp!(L::Laplacian,a[,Nodes(Dual)][;nthreads=L.conv.nthreads])
@@ -151,14 +151,16 @@ for (datatype) in (:Nodes, :XEdges, :YEdges)
                      E::IntFact{MX, MY, NegExp, inplace},
                      s::$datatype{T, NX, NY}) where {T <: CellType, NX, NY, MX, MY, inplace}
 
-      out .= deepcopy(s)
+      #out .= deepcopy(s)
+      out .= s
   end
 
   @eval function ldiv!(out::$datatype{T,NX, NY},
                      E::IntFact{MX, MY, PosExp, inplace},
                      s::$datatype{T, NX, NY}) where {T <: CellType, NX, NY, MX, MY, inplace}
 
-      out .= deepcopy(s)
+      #out .= deepcopy(s)
+      out .= s
   end
 
   @eval function ldiv!(out::$datatype{T,NX, NY},
@@ -173,13 +175,15 @@ for (datatype) in (:Nodes, :XEdges, :YEdges)
   @eval function mul!(out::$datatype{T,NX, NY},
                      E::IntFact{MX, MY, ZeroExp, inplace},
                      s::$datatype{T, NX, NY}) where {T <: CellType, NX, NY, MX, MY, inplace}
-      out .= deepcopy(s)
+      #out .= deepcopy(s)
+      out .= s
   end
 
   @eval function ldiv!(out::$datatype{T,NX, NY},
                      E::IntFact{MX, MY, ZeroExp, inplace},
                      s::$datatype{T, NX, NY}) where {T <: CellType, NX, NY, MX, MY, inplace}
-      out .= deepcopy(s)
+      #out .= deepcopy(s)
+      out .= s
   end
 
 end


### PR DESCRIPTION
This PR addresses a few annoying unnecessary memory allocations
- In the calculation of dot products of grid data, where it previously was not using `view` to access parts of the grid
- In the operation of integrating factors with zero exponents, where it was using an unnecessary `deepcopy`