### PR TITLE
Remove multithreading as default

### DIFF
--- a/benchmark/setupproblem.jl
+++ b/benchmark/setupproblem.jl
@@ -1,7 +1,7 @@
 Δx = 0.01
 xlim = (-2,2)
 ylim = (-2,2)
-gr = PhysicalGrid(xlim,ylim,Δx)
+gr = PhysicalGrid(xlim,ylim,Δx,opt_type=:prime,nthreads_max=4)
 w = Nodes(Dual,size(gr));
 q = Edges(Primal,w);
 p = Nodes(Primal,w);

--- a/benchmark/setupproblem.jl
+++ b/benchmark/setupproblem.jl
@@ -6,7 +6,7 @@ w = Nodes(Dual,size(gr));
 q = Edges(Primal,w);
 p = Nodes(Primal,w);
 
-L = plan_laplacian(w,with_inverse=true);
+L = plan_laplacian(gr,with_inverse=true);
 
 n = 300
 θ = range(0,2π,length=n+1)

--- a/src/CartesianGrids.jl
+++ b/src/CartesianGrids.jl
@@ -75,6 +75,7 @@ const TENSORLIST = [:EdgeGradient, [:Dual,:Primal]],
 
 
 const MAX_NTHREADS = length(Sys.cpu_info())
+const DEFAULT_NTHREADS = 1
 
 function othertype end
 

--- a/src/gridoperations/convolution.jl
+++ b/src/gridoperations/convolution.jl
@@ -49,7 +49,7 @@ function Base.show(io::IO, c::CircularConvolution{M, N, T}) where {M, N, T}
     print(io, "Circular convolution on a $M × $N matrix of data type $T")
 end
 
-function CircularConvolution(G::AbstractMatrix{T},fftw_flags = FFTW.ESTIMATE; dtype = Float64, optimize = true, nthreads = MAX_NTHREADS) where {T}
+function CircularConvolution(G::AbstractMatrix{T},fftw_flags = FFTW.ESTIMATE; dtype = Float64, optimize = true, nthreads = DEFAULT_NTHREADS) where {T}
   nt_opt = nthreads
   if optimize
     # find the optimal number of threads, up to `nthreads`

--- a/src/gridoperations/helmholtz.jl
+++ b/src/gridoperations/helmholtz.jl
@@ -99,24 +99,24 @@ end
 for (lf,inplace) in ((:plan_helmholtz,false),
                      (:plan_helmholtz!,true))
     @eval function $lf(dims::Tuple{Int,Int},α::Number;
-                   with_inverse = false, fftw_flags = FFTW.ESTIMATE, factor::Number = 1.0, dx = 1.0, nthreads = MAX_NTHREADS)
+                   with_inverse = false, fftw_flags = FFTW.ESTIMATE, factor::Number = 1.0, dx = 1.0, optimize=false, nthreads = DEFAULT_NTHREADS)
         NX, NY = dims
         if !with_inverse
             return Helmholtz{NX, NY, false, dx, $inplace}(α,convert(ComplexF64,factor),nothing)
         end
         lgfh_table = load_lgf_helmholtz(NX+1,α)
         G = view(lgfh_table, 1:NX, 1:NY)
-        Helmholtz{NX, NY, true, dx, $inplace}(α,convert(ComplexF64,factor),CircularConvolution(G, fftw_flags,dtype=ComplexF64,nthreads=nthreads))
+        Helmholtz{NX, NY, true, dx, $inplace}(α,convert(ComplexF64,factor),CircularConvolution(G, fftw_flags,dtype=ComplexF64,optimize=optimize,nthreads=nthreads))
     end
 
     @eval function $lf(nx::Int, ny::Int,α::Number;
-        with_inverse = false, fftw_flags = FFTW.ESTIMATE, factor::Number = 1.0, dx = 1.0, nthreads = MAX_NTHREADS)
-        $lf((nx, ny), α, with_inverse = with_inverse, fftw_flags = fftw_flags, factor = factor, dx = dx, nthreads = nthreads)
+        with_inverse = false, fftw_flags = FFTW.ESTIMATE, factor::Number = 1.0, dx = 1.0, optimize=false, nthreads = DEFAULT_NTHREADS)
+        $lf((nx, ny), α, with_inverse = with_inverse, fftw_flags = fftw_flags, factor = factor, dx = dx, optimize=optimize, nthreads = nthreads)
     end
 
     @eval function $lf(::GridData{NX,NY,T},α::Number;
-        with_inverse = false, fftw_flags = FFTW.ESTIMATE, factor::Number = 1.0, dx = 1.0, nthreads = MAX_NTHREADS) where {NX,NY,T<:ComplexF64}
-        $lf((NX,NY), α, with_inverse = with_inverse, fftw_flags = fftw_flags, factor = factor, dx = dx, nthreads = nthreads)
+        with_inverse = false, fftw_flags = FFTW.ESTIMATE, factor::Number = 1.0, dx = 1.0, optimize=false, nthreads = DEFAULT_NTHREADS) where {NX,NY,T<:ComplexF64}
+        $lf((NX,NY), α, with_inverse = with_inverse, fftw_flags = fftw_flags, factor = factor, dx = dx, optimize = optimize, nthreads = nthreads)
     end
 end
 

--- a/src/gridoperations/implicitdiffusion.jl
+++ b/src/gridoperations/implicitdiffusion.jl
@@ -38,7 +38,7 @@ end
 for (lf,inplace) in ((:plan_implicit_diffusion,false),
                      (:plan_implicit_diffusion!,true))
 
-    @eval function $lf(a::Real,dims::Tuple{Int,Int};fftw_flags = FFTW.ESTIMATE, nthreads = MAX_NTHREADS)
+    @eval function $lf(a::Real,dims::Tuple{Int,Int};fftw_flags = FFTW.ESTIMATE, optimize = false, nthreads = DEFAULT_NTHREADS)
         NX, NY = dims
 
         # Find the minimum number of Gauss points
@@ -64,13 +64,13 @@ for (lf,inplace) in ((:plan_implicit_diffusion,false),
         # Create the table of values
         qtab = [max(x,y) <= Nmax ? implicit_diffusion(x, y, a, quad) : 0.0 for x in 0:NX-1, y in 0:NY-1]
 
-        ImplicitDiffusion{NX, NY, $inplace}(a,CircularConvolution(qtab, fftw_flags,nthreads=nthreads))
+        ImplicitDiffusion{NX, NY, $inplace}(a,CircularConvolution(qtab, fftw_flags,optimize=optimize,nthreads=nthreads))
       end
 
       # Base the size on the dual grid associated with any grid data, since this
       # is what the efficient grid size in PhysicalGrid has been established with
-      @eval $lf(a::Real,::GridData{NX,NY}; fftw_flags = FFTW.ESTIMATE, nthreads = MAX_NTHREADS) where {NX,NY} =
-          $lf(a,(NX,NY), fftw_flags = fftw_flags, nthreads = nthreads)
+      @eval $lf(a::Real,::GridData{NX,NY}; fftw_flags = FFTW.ESTIMATE, optimize=false, nthreads = DEFAULT_NTHREADS) where {NX,NY} =
+          $lf(a,(NX,NY), fftw_flags = fftw_flags, optimize=optimize, nthreads = nthreads)
 
 
 end

--- a/src/gridoperations/intfact.jl
+++ b/src/gridoperations/intfact.jl
@@ -75,7 +75,7 @@ end
 for (lf,inplace) in ((:plan_intfact,false),
                      (:plan_intfact!,true))
 
-    @eval function $lf(a::Real,dims::Tuple{Int,Int};fftw_flags = FFTW.ESTIMATE, nthreads = MAX_NTHREADS)
+    @eval function $lf(a::Real,dims::Tuple{Int,Int};fftw_flags = FFTW.ESTIMATE, optimize=false, nthreads = DEFAULT_NTHREADS)
         NX, NY = dims
 
         if a == 0
@@ -95,13 +95,13 @@ for (lf,inplace) in ((:plan_intfact,false),
         end
         qtab = [max(x,y) <= Nmax ? intfact(x, y, a_internal) : 0.0 for x in 0:NX-1, y in 0:NY-1]
         #IntFact{NX, NY, a, $inplace}(Nullable(CircularConvolution(qtab, fftw_flags)))
-        IntFact{NX, NY, signType, $inplace}(a_internal,CircularConvolution(qtab, fftw_flags,nthreads=nthreads))
+        IntFact{NX, NY, signType, $inplace}(a_internal,CircularConvolution(qtab, fftw_flags,optimize=optimize,nthreads=nthreads))
       end
 
       # Base the size on the dual grid associated with any grid data, since this
       # is what the efficient grid size in PhysicalGrid has been established with
-      @eval $lf(a::Real,::GridData{NX,NY}; fftw_flags = FFTW.ESTIMATE, nthreads = MAX_NTHREADS) where {NX,NY} =
-          $lf(a,(NX,NY), fftw_flags = fftw_flags, nthreads = nthreads)
+      @eval $lf(a::Real,::GridData{NX,NY}; fftw_flags = FFTW.ESTIMATE, optimize=false, nthreads = DEFAULT_NTHREADS) where {NX,NY} =
+          $lf(a,(NX,NY), fftw_flags = fftw_flags, optimize=optimize, nthreads = nthreads)
 
 
 end
@@ -123,7 +123,7 @@ it scales the exponent with this factor. The number of threads used by
 the resulting operator can be set by the `nthreads` optional argument; by
 default, it takes this number from `L`.
 """
-exp(L::Laplacian{NX,NY},a,prototype=Nodes(Dual,(NX,NY));nthreads=MAX_NTHREADS) where {NX,NY} =
+exp(L::Laplacian{NX,NY},a,prototype=Nodes(Dual,(NX,NY));nthreads=DEFAULT_NTHREADS) where {NX,NY} =
             plan_intfact(L.factor*a,prototype;nthreads=nthreads)
 # Do not use the number of threads in L (if it has any), since it is not
 # meaningful for the integrating factor tests.
@@ -133,7 +133,7 @@ exp(L::Laplacian{NX,NY},a,prototype=Nodes(Dual,(NX,NY));nthreads=MAX_NTHREADS) w
 
 Create the in-place version of the integrating factor exp(L*a).
 """
-exp!(L::Laplacian{NX,NY},a,prototype=Nodes(Dual,(NX,NY));nthreads=MAX_NTHREADS) where {NX,NY} =
+exp!(L::Laplacian{NX,NY},a,prototype=Nodes(Dual,(NX,NY));nthreads=DEFAULT_NTHREADS) where {NX,NY} =
             plan_intfact!(L.factor*a,prototype;nthreads=nthreads)
 
 

--- a/src/gridoperations/laplacian.jl
+++ b/src/gridoperations/laplacian.jl
@@ -273,26 +273,26 @@ Base.eltype(::Laplacian{NX,NY,T}) where {NX,NY,T} = T
 for (lf,inplace) in ((:plan_laplacian,false),
                      (:plan_laplacian!,true))
     @eval function $lf(dims::Tuple{Int,Int};
-                   with_inverse = false, fftw_flags = FFTW.ESTIMATE, factor::Real = 1.0, dx = 1.0, dtype = Float64, nthreads = MAX_NTHREADS)
+                   with_inverse = false, fftw_flags = FFTW.ESTIMATE, factor::Real = 1.0, dx = 1.0, dtype = Float64, optimize=false, nthreads = DEFAULT_NTHREADS)
         NX, NY = dims
         if !with_inverse
             return Laplacian{NX, NY, dtype, false, $inplace}(convert(dtype,factor),convert(Float64,dx),nothing)
         end
 
         G = view(LGF_TABLE, 1:NX, 1:NY)
-        Laplacian{NX, NY, dtype, true, $inplace}(convert(dtype,factor),convert(Float64,dx),CircularConvolution(G, fftw_flags,dtype=dtype,nthreads=nthreads))
+        Laplacian{NX, NY, dtype, true, $inplace}(convert(dtype,factor),convert(Float64,dx),CircularConvolution(G, fftw_flags,dtype=dtype,optimize=optimize,nthreads=nthreads))
     end
 
     @eval function $lf(nx::Int, ny::Int;
-        with_inverse = false, fftw_flags = FFTW.ESTIMATE, factor = 1.0, dx = 1.0, dtype = Float64, nthreads = MAX_NTHREADS)
-        $lf((nx, ny), with_inverse = with_inverse, fftw_flags = fftw_flags, factor = factor, dx = dx, dtype = dtype, nthreads = nthreads)
+        with_inverse = false, fftw_flags = FFTW.ESTIMATE, factor = 1.0, dx = 1.0, dtype = Float64, optimize=false, nthreads = DEFAULT_NTHREADS)
+        $lf((nx, ny), with_inverse = with_inverse, fftw_flags = fftw_flags, factor = factor, dx = dx, dtype = dtype, optimize=optimize, nthreads = nthreads)
     end
 
     # Base the size on the dual grid associated with any grid data, since this
     # is what the efficient grid size in PhysicalGrid has been established with
     @eval function $lf(::GridData{NX,NY};
-        with_inverse = false, fftw_flags = FFTW.ESTIMATE, factor = 1.0, dx = 1.0, dtype = Float64, nthreads = MAX_NTHREADS) where {NX,NY}
-        $lf((NX,NY), with_inverse = with_inverse, fftw_flags = fftw_flags, factor = factor, dx = dx, dtype = dtype, nthreads = nthreads)
+        with_inverse = false, fftw_flags = FFTW.ESTIMATE, factor = 1.0, dx = 1.0, dtype = Float64, optimize=false, nthreads = DEFAULT_NTHREADS) where {NX,NY}
+        $lf((NX,NY), with_inverse = with_inverse, fftw_flags = fftw_flags, factor = factor, dx = dx, dtype = dtype, optimize=optimize, nthreads = nthreads)
     end
 end
 

--- a/src/physical/physicalgrid.jl
+++ b/src/physical/physicalgrid.jl
@@ -322,3 +322,6 @@ plan_intfact!(a::Real,g::PhysicalGrid;kwargs...) = plan_intfact!(a,size(g);nthre
 
 plan_helmholtz(g::PhysicalGrid,α::Number;kwargs...) = plan_helmholtz(size(g),α;nthreads=g.nthreads,kwargs...)
 plan_helmholtz!(g::PhysicalGrid,α::Number;kwargs...) = plan_helmholtz!(size(g),α;nthreads=g.nthreads,kwargs...)
+
+plan_implicit_diffusion(a::Number,g::PhysicalGrid;kwargs...) = plan_implicit_diffusion(a,size(g);nthreads=g.nthreads,kwargs...)
+plan_implicit_diffusion!(a::Number,g::PhysicalGrid;kwargs...) = plan_implicit_diffusion!(a,size(g);nthreads=g.nthreads,kwargs...)

--- a/src/physical/physicalgrid.jl
+++ b/src/physical/physicalgrid.jl
@@ -63,7 +63,7 @@ of the cell to which the physical origin corresponds. Note that the corner
 corresponding to the lowest limit in each direction has indices (1,1).
 """
 function PhysicalGrid(xlim::Tuple{Real,Real},
-                      ylim::Tuple{Real,Real},Δx::Float64;optimize=true,nthreads_max=MAX_NTHREADS)
+                      ylim::Tuple{Real,Real},Δx::Float64;optimize=true,nthreads_max=DEFAULT_NTHREADS)
 
 
   #= set grid spacing and the grid position of the origin
@@ -168,15 +168,15 @@ function test_cputime(nx,ny,nthreads_max;nsamp=1,testtype=:laplacian,kwargs...)
     return mean(cput), std(cput)
 end
 
-_cputime_test_operator(w::GridData,nthreads_max,::Val{:laplacian}) = plan_laplacian(w,with_inverse=true,nthreads=nthreads_max)
+_cputime_test_operator(w::GridData,nthreads_max,::Val{:laplacian}) = plan_laplacian(w,with_inverse=true,optimize=true,nthreads=nthreads_max)
 
 function _cputime_test_operator(w::GridData,nthreads_max,::Val{:intfact};a=-1.0)
-  L = plan_laplacian(w,with_inverse=true,nthreads=nthreads_max)
+  L = plan_laplacian(w,with_inverse=true,optimize=true,nthreads=nthreads_max)
   return exp(L,a,w)
 end
 
 _cputime_test_operator(w::GridData,nthreads_max,::Val{:helmholtz};α=0.1) =
-      plan_helmholtz(w,α,with_inverse=true,nthreads=nthreads_max)
+      plan_helmholtz(w,α,with_inverse=true,optimize=true,nthreads=nthreads_max)
 
 
 """
@@ -187,7 +187,7 @@ that minimizes the compute time. Optional arguments are the maximum number
 of threads (if multithreading is allowed) and the number of samples to take
 of the cpu time for each trial. Returns optimal `nx`, `ny`, and the corresponding CPU time.
 """
-function optimize_gridsize(nx0,ny0;region_size=4,nthreads_max=MAX_NTHREADS,kwargs...)
+function optimize_gridsize(nx0,ny0;region_size=4,nthreads_max=DEFAULT_NTHREADS,kwargs...)
     cput0_mean, cput0_std = test_cputime(nx0,ny0,nthreads_max;kwargs...)
     nx_opt, ny_opt = nx0, ny0
     cput_mean_opt = cput0_mean

--- a/test/fields.jl
+++ b/test/fields.jl
@@ -1150,5 +1150,11 @@ end
         @test cellsize(g) == 0.02
         @test Threads.nthreads(g) == 1
 
+        g = PhysicalGrid((-1.0,3.0),(-2.0,3.0),0.02,opt_type=:prime)
+        xc, yc = coordinates(Nodes(Primal,size(g)),g)
+        i0 = findall(x -> x ≈ 0.0,xc)
+        j0 = findall(y -> y ≈ 0.0,yc)
+        @test length(i0) == 1 && length(j0) == 1
+
     end
 end


### PR DESCRIPTION
This PR cleans up some issues with multithreading
- It removes multithreading as a default, since it is better for the user to explicitly set it
- It uses the older prime factorization approach to choosing an optimal grid size
- It provides both prime factorization (`:prime`)and threading (`:threads`) as possible optimization approaches when setting the grid, with `:prime` as default. These are set with the `opt_type` keyword to `PhysicalGrid`.

The benchmark tests show that the prime approach with multiple threads gives far superior results than the trial-and-error results of setting grid size.