### PR TITLE
Changed the exp function on Laplacian to only accept a single argument

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,25 +10,16 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.10'
           - 'nightly'
         os:
           - ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
@@ -42,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.6'
+          version: '1.10'
       - run: |
           julia --project=docs -e '
             using Pkg

--- a/src/gridoperations/intfact.jl
+++ b/src/gridoperations/intfact.jl
@@ -114,27 +114,28 @@ function Base.show(io::IO, E::IntFact{NX, NY, signType, inplace}) where {NX, NY,
 end
 
 """
-    exp(L::Laplacian,a[,Nodes(Dual)][;nthreads=L.conv.nthreads])
+    exp(L::Laplacian[,Nodes(Dual)][;nthreads=L.conv.nthreads])
 
-Create the integrating factor exp(L*a). The default size of the operator is
+Create the integrating factor exp(L). The default size of the operator is
 the one appropriate for dual nodes; another size can be specified by supplying
 grid data in the optional third argument. Note that, if `L` contains a factor,
+e.g., by multiplying a `Laplacian` by a scalar,
 it scales the exponent with this factor. The number of threads used by
 the resulting operator can be set by the `nthreads` optional argument; by
 default, it takes this number from `L`.
 """
-exp(L::Laplacian{NX,NY},a,prototype=Nodes(Dual,(NX,NY));nthreads=DEFAULT_NTHREADS) where {NX,NY} =
-            plan_intfact(L.factor*a,prototype;nthreads=nthreads)
+exp(L::Laplacian{NX,NY},prototype=Nodes(Dual,(NX,NY));nthreads=DEFAULT_NTHREADS) where {NX,NY} =
+            plan_intfact(L.factor,prototype;nthreads=nthreads)
 # Do not use the number of threads in L (if it has any), since it is not
 # meaningful for the integrating factor tests.
 
 """
-    exp!(L::Laplacian,a[,Nodes(Dual)][;nthreads=L.conv.nthreads])
+    exp!(L::Laplacian[,Nodes(Dual)][;nthreads=L.conv.nthreads])
 
-Create the in-place version of the integrating factor exp(L*a).
+Create the in-place version of the integrating factor exp(L).
 """
-exp!(L::Laplacian{NX,NY},a,prototype=Nodes(Dual,(NX,NY));nthreads=DEFAULT_NTHREADS) where {NX,NY} =
-            plan_intfact!(L.factor*a,prototype;nthreads=nthreads)
+exp!(L::Laplacian{NX,NY},prototype=Nodes(Dual,(NX,NY));nthreads=DEFAULT_NTHREADS) where {NX,NY} =
+            plan_intfact!(L.factor,prototype;nthreads=nthreads)
 
 
 

--- a/test/fields.jl
+++ b/test/fields.jl
@@ -1017,8 +1017,12 @@ end
         @test s ≈ E2*s2
 
         L = plan_laplacian(s,factor=2)
-        EL = exp(L,1)
+        EL = exp(L)
         @test EL*s ≈ E2*s
+
+        L2 = plan_laplacian(s)
+        EL2 = exp(2*L2)
+        @test EL2*s ≈ E2*s
 
         p = XEdges(Primal,s)
         p[15,15] = 1.0
@@ -1028,7 +1032,7 @@ end
         q.u[15,15] = 1.0
         @test E1*(E1*q) ≈ E2*q
 
-        EmL = exp(L,-1)
+        EmL = exp(-1*L)
         @test EmL\s == EL*s
 
     end


### PR DESCRIPTION
This PR changes `exp(L::Laplacian,a)` to `exp(L)`, where `L.factor` contains all desired factors. This is straightforward since `a*L` produces a `Laplacian` with factor `a*L.factor`.